### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ dependencies = [
     "math-verify==0.6.0",
     "lark",
     "sympy",
-    "levenshtein"
+    "levenshtein",
+    "datasets==3.6.0"
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
datasets needs to be < 4.0.0 or you get this issue:

```
$ uv run python -m scripts.generate_launch_commands > launch_commands
/orcd/home/002/nziems/gepa-artifact/.venv/lib/python3.11/site-packages/torch/cuda/__init__.py:789: UserWarning: Can't initialize NVML
  warnings.warn("Can't initialize NVML")
`trust_remote_code` is not supported anymore.
Please check that the Hugging Face dataset 'hover' isn't based on a loading script and remove `trust_remote_code`.
If the dataset is based on a loading script, please ask the dataset author to remove it and convert it to a standard format like Parquet.
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/orcd/home/002/nziems/gepa-artifact/scripts/generate_launch_commands.py", line 18, in <module>
    benchmark = benchmark_meta.benchmark(dataset_mode=dataset_mode) if dataset_mode else benchmark_meta.benchmark()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/orcd/home/002/nziems/gepa-artifact/gepa_artifact/benchmarks/benchmark.py", line 18, in __init__
    self.init_dataset()
  File "/orcd/home/002/nziems/gepa-artifact/gepa_artifact/benchmarks/hover/hover_data.py", line 11, in init_dataset
    dataset = load_dataset("hover", trust_remote_code=True)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/orcd/home/002/nziems/gepa-artifact/.venv/lib/python3.11/site-packages/datasets/load.py", line 1392, in load_dataset
    builder_instance = load_dataset_builder(
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/orcd/home/002/nziems/gepa-artifact/.venv/lib/python3.11/site-packages/datasets/load.py", line 1132, in load_dataset_builder
    dataset_module = dataset_module_factory(
                     ^^^^^^^^^^^^^^^^^^^^^^^
  File "/orcd/home/002/nziems/gepa-artifact/.venv/lib/python3.11/site-packages/datasets/load.py", line 1031, in dataset_module_factory
    raise e1 from None
  File "/orcd/home/002/nziems/gepa-artifact/.venv/lib/python3.11/site-packages/datasets/load.py", line 989, in dataset_module_factory
    raise RuntimeError(f"Dataset scripts are no longer supported, but found {filename}")
RuntimeError: Dataset scripts are no longer supported, but found hover.py
```