### PR TITLE
Fix aliased list bug corrupting seed program's val subscores

### DIFF
--- a/gepa_artifact/gepa/gepa_utils.py
+++ b/gepa_artifact/gepa/gepa_utils.py
@@ -91,8 +91,8 @@ class GEPAState:
         self.rng1 = random.Random(seed)
         self.rng2 = random.Random(seed+1)
 
-        self.prog_candidate_train_subscores = [base_trainset_eval_output[2]]
-        self.prog_candidate_val_subscores = [base_valset_eval_output[2]]
+        self.prog_candidate_train_subscores = [list(base_trainset_eval_output[2])]
+        self.prog_candidate_val_subscores = [list(base_valset_eval_output[2])]
         self.num_metric_calls_by_discovery = [0]
 
         self.running_linearized_gepa = run_linearized_gepa


### PR DESCRIPTION
## Summary
- `prog_candidate_val_subscores[0]` and `pareto_front_valset` were assigned the same list object at `GEPAState` init (lines 83 & 95 of `gepa_utils.py`). When `update_state_with_new_program` mutated `pareto_front_valset[task_idx]` in-place (line 202), it silently overwrote program 0's recorded subscores, making them equal to the per-task max across all programs.
- Fixed by wrapping in `list()` at init so each field is an independent copy. Applied the same defensive fix to `prog_candidate_train_subscores`.

## Why the trainset side was unaffected
The trainset pareto front update goes through `update_pareto_front()`, which `deepcopy`s before mutating and returns a new list — breaking the alias. The valset side mutated in-place instead.

## Test plan
- [ ] Load a completed run's `gepa_state` and verify `prog_candidate_val_subscores[0]` now matches the seed program's actual valset scores, not the per-task max

🤖 Generated with [Claude Code](https://claude.com/claude-code)